### PR TITLE
To retain the custom domain when deploying

### DIFF
--- a/sched-ext/static/CNAME
+++ b/sched-ext/static/CNAME
@@ -1,0 +1,1 @@
+sched-ext.com


### PR DESCRIPTION
In order to retain the custom domain when deploying the website we need a CNAME file in the root.